### PR TITLE
Update workflows: pin actions, adjust schedules, and use bot commit identity

### DIFF
--- a/.github/workflows/contributions-as-profile-3d.yaml
+++ b/.github/workflows/contributions-as-profile-3d.yaml
@@ -2,7 +2,7 @@ name: Generate Contributions as Profile 3D
 
 on:
   schedule:
-    - cron: "0 5 * * *"
+    - cron: "17 5 * * *"
   workflow_dispatch:
 
 jobs:
@@ -11,16 +11,16 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: yoshi389111/github-profile-3d-contrib@0.9.2
+      - uses: actions/checkout@v6.0.2
+      - uses: yoshi389111/github-profile-3d-contrib@v0.9.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           USERNAME: ${{ github.repository_owner }}
           MAX_REPOS: 250
       - name: Commit & Push
         run: |
-          git config user.name ${{ github.repository_owner }}
-          git config user.email georges.ahombo@gmail.com
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A .
           if git commit -m "update: GitHub 3D Profile"; then
             git push

--- a/.github/workflows/contributions-as-snake-game.yaml
+++ b/.github/workflows/contributions-as-snake-game.yaml
@@ -2,28 +2,28 @@ name: Generate Contributions as Snake Game
 
 on:
   schedule:
-    - cron: "0 */24 * * *"
+    - cron: "43 0 * * *"
   workflow_dispatch:
-  push:
-    branches:
-      - main
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: Platane/snk@v3
+      - uses: actions/checkout@v6.0.2
+      - uses: Platane/snk@v3.4.1
         id: snake-gif
         with:
           github_user_name: georgesnoe
-          outputs: github-contributions-grid-snake.svg
+          outputs: github-contribution-grid-snake.svg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Commit & Push
         run: |
-          git config user.name ${{ github.repository_owner }}
-          git config user.email georges.ahombo@gmail.com
-          git add github-contributions-grid-snake.svg
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add github-contribution-grid-snake.svg
           if git commit -m "update: GitHub Snake Game Contributions"; then
             git push
           fi


### PR DESCRIPTION
### Motivation
- Update scheduled contribution-image workflows to use specific action versions and a safer commit identity. 
- Fix minor filename and action input mismatches and ensure workflows have correct permissions for pushing artifacts.

### Description
- Updated `.github/workflows/contributions-as-profile-3d.yaml` to change the cron from `0 5 * * *` to `17 5 * * *`, pin `actions/checkout` to `@v6.0.2`, normalize the profile-action tag to `v0.9.2`, and set the commit user/email to the `github-actions[bot]` noreply account. 
- Updated `.github/workflows/contributions-as-snake-game.yaml` to change the cron from `0 */24 * * *` to `43 0 * * *`, remove the explicit `push` trigger, add `permissions: contents: write`, replace the single `Platane/snk@v3` step with a pinned `actions/checkout@v6.0.2` plus `Platane/snk@v3.4.1`, correct the action output filename to `github-contribution-grid-snake.svg`, and set the commit user/email to the `github-actions[bot]` noreply account. 
- Adjusted `git add` paths and commit messages to match the renamed output file and unified commit identity.

### Testing
- No automated tests were executed for these workflow YAML changes. 
- Changes are limited to CI workflow configuration and were reviewed as a YAML diff for consistency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5243d84d48332a0f43744db2abb92)