### PR TITLE
Update GitHub Actions workflows (checkout, bot identity, schedules) and add 3D contributions image

### DIFF
--- a/.github/workflows/contributions-as-profile-3d.yaml
+++ b/.github/workflows/contributions-as-profile-3d.yaml
@@ -2,7 +2,7 @@ name: Generate Contributions as Profile 3D
 
 on:
   schedule:
-    - cron: "0 5 * * *"
+    - cron: "17 5 * * *"
   workflow_dispatch:
 
 jobs:
@@ -11,16 +11,16 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: yoshi389111/github-profile-3d-contrib@0.9.2
+      - uses: actions/checkout@v6.0.2
+      - uses: yoshi389111/github-profile-3d-contrib@v0.9.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           USERNAME: ${{ github.repository_owner }}
           MAX_REPOS: 250
       - name: Commit & Push
         run: |
-          git config user.name ${{ github.repository_owner }}
-          git config user.email georges.ahombo@gmail.com
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A .
           if git commit -m "update: GitHub 3D Profile"; then
             git push

--- a/.github/workflows/contributions-as-snake-game.yaml
+++ b/.github/workflows/contributions-as-snake-game.yaml
@@ -2,28 +2,28 @@ name: Generate Contributions as Snake Game
 
 on:
   schedule:
-    - cron: "0 */24 * * *"
+    - cron: "43 0 * * *"
   workflow_dispatch:
-  push:
-    branches:
-      - main
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: Platane/snk@v3
+      - uses: actions/checkout@v6.0.2
+      - uses: Platane/snk@v3.4.1
         id: snake-gif
         with:
           github_user_name: georgesnoe
-          outputs: github-contributions-grid-snake.svg
+          outputs: github-contribution-grid-snake.svg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Commit & Push
         run: |
-          git config user.name ${{ github.repository_owner }}
-          git config user.email georges.ahombo@gmail.com
-          git add github-contributions-grid-snake.svg
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add github-contribution-grid-snake.svg
           if git commit -m "update: GitHub Snake Game Contributions"; then
             git push
           fi

--- a/README.md
+++ b/README.md
@@ -41,4 +41,8 @@ I also speak French, English and a bit of Spanish and Deutsch
 
 ![GitHub graph](https://github-readme-activity-graph.vercel.app/graph?username=georgesnoe&theme=react-dark&hide_border=true&area=true)
 
+## 3D Contributions
+
+![GitHub 3D Contribution Profile](./profile-3d-contrib/profile-night-rainbow.svg)
+
 ![GitHub Snake Game](github-contribution-grid-snake.svg)


### PR DESCRIPTION
### Motivation

- Standardize workflow behavior by using explicit action versions and a bot identity for commits.
- Adjust scheduled run times to stagger generation of contribution artifacts.
- Ensure generated contribution assets are tracked with correct filenames and expose the 3D profile artifact in the README.

### Description

- Updated `/.github/workflows/contributions-as-profile-3d.yaml` to change the cron from `"0 5 * * *"` to `"17 5 * * *"`, pin `actions/checkout` to `@v6.0.2`, use `yoshi389111/github-profile-3d-contrib@v0.9.2`, and set commit `user.name`/`user.email` to the GitHub Actions bot values.
- Updated `/.github/workflows/contributions-as-snake-game.yaml` to change the cron from `"0 */24 * * *"` to `"43 0 * * *"`, add `permissions.contents: write`, pin `actions/checkout@v6.0.2`, upgrade `Platane/snk` to `@v3.4.1`, fix the output filename from `github-contributions-grid-snake.svg` to `github-contribution-grid-snake.svg`, remove the explicit `push` trigger, and set commit `user.name`/`user.email` to the GitHub Actions bot values.
- Updated `README.md` to add a `3D Contributions` section and include the `./profile-3d-contrib/profile-night-rainbow.svg` image and ensure the snake game image reference matches the generated filename.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5243d84d48332a0f43744db2abb92)